### PR TITLE
Master - Table flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Options:
 
   -dir string
     	directory with migration files (default ".")
+  -table string
+    	migrations table name (default "goose_db_version")
   -h	print help
   -v	enable verbose mode
   -version

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	flags   = flag.NewFlagSet("goose", flag.ExitOnError)
-	dir     = flags.String("dir", "", "directory with migration files")
+	dir     = flags.String("dir", ".", "directory with migration files")
 	table   = flags.String("table", "goose_db_version", "migrations table name")
 	verbose = flags.Bool("v", false, "enable verbose mode")
 	help    = flags.Bool("h", false, "print help")
@@ -30,7 +30,10 @@ func main() {
 	if *verbose {
 		goose.SetVerbose(true)
 	}
-	goose.SetTableName(*table)
+
+	if (*table)[:6] == "goose_" {
+		goose.SetTableName(*table)
+	}
 
 	args := flags.Args()
 	if len(args) == 0 || *help {

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -12,7 +12,8 @@ import (
 
 var (
 	flags   = flag.NewFlagSet("goose", flag.ExitOnError)
-	dir     = flags.String("dir", ".", "directory with migration files")
+	dir     = flags.String("dir", "", "directory with migration files")
+	table   = flags.String("table", "goose_db_version", "migrations table name")
 	verbose = flags.Bool("v", false, "enable verbose mode")
 	help    = flags.Bool("h", false, "print help")
 	version = flags.Bool("version", false, "print version")
@@ -29,6 +30,7 @@ func main() {
 	if *verbose {
 		goose.SetVerbose(true)
 	}
+	goose.SetTableName(*table)
 
 	args := flags.Args()
 	if len(args) == 0 || *help {

--- a/up.go
+++ b/up.go
@@ -86,7 +86,11 @@ func UpUnapplied(db *sql.DB, dir string) error {
 
 		// Look up if the migration has been applied.
 		var row MigrationRecord
-		q := fmt.Sprintf("SELECT tstamp, is_applied FROM goose_db_version WHERE version_id=%d ORDER BY tstamp DESC LIMIT 1", migration.Version)
+		q := fmt.Sprintf(
+			"SELECT tstamp, is_applied FROM %s WHERE version_id=%d ORDER BY tstamp DESC LIMIT 1",
+			TableName(),
+			migration.Version,
+		)
 		err := db.QueryRow(q).Scan(&row.TStamp, &row.IsApplied)
 
 		if err != nil && err != sql.ErrNoRows {


### PR DESCRIPTION
Allow migrations table to be specified.
This will allow us to put seed data into a different migrations track than regular migrations